### PR TITLE
EGLRender texture position use FboTexCoors

### DIFF
--- a/app/src/main/cpp/render/EGLRender.cpp
+++ b/app/src/main/cpp/render/EGLRender.cpp
@@ -384,7 +384,7 @@ void EGLRender::Init()
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vVertices), vVertices, GL_STATIC_DRAW);
 
 	glBindBuffer(GL_ARRAY_BUFFER, m_VboIds[1]);
-	glBufferData(GL_ARRAY_BUFFER, sizeof(vFboTexCoors), vTexCoors, GL_STATIC_DRAW);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(vFboTexCoors), vFboTexCoors, GL_STATIC_DRAW);
 
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_VboIds[2]);
 	glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);

--- a/app/src/main/java/com/byteflow/app/egl/EGLActivity.java
+++ b/app/src/main/java/com/byteflow/app/egl/EGLActivity.java
@@ -148,27 +148,24 @@ public class EGLActivity extends AppCompatActivity {
 
     private Bitmap createBitmapFromGLSurface(int x, int y, int w, int h) {
         int bitmapBuffer[] = new int[w * h];
-        int bitmapSource[] = new int[w * h];
         IntBuffer intBuffer = IntBuffer.wrap(bitmapBuffer);
         intBuffer.position(0);
         try {
             GLES20.glReadPixels(x, y, w, h, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE,
                     intBuffer);
-            int offset1, offset2;
             for (int i = 0; i < h; i++) {
-                offset1 = i * w;
-                offset2 = (h - i - 1) * w;
                 for (int j = 0; j < w; j++) {
-                    int texturePixel = bitmapBuffer[offset1 + j];
+                    int index = i * w + j;
+                    int texturePixel = bitmapBuffer[index];
                     int blue = (texturePixel >> 16) & 0xff;
                     int red = (texturePixel << 16) & 0x00ff0000;
                     int pixel = (texturePixel & 0xff00ff00) | red | blue;
-                    bitmapSource[offset2 + j] = pixel;
+                    bitmapBuffer[index] = pixel;
                 }
             }
         } catch (GLException e) {
             return null;
         }
-        return Bitmap.createBitmap(bitmapSource, w, h, Bitmap.Config.ARGB_8888);
+        return Bitmap.createBitmap(bitmapBuffer, w, h, Bitmap.Config.ARGB_8888);
     }
 }


### PR DESCRIPTION
在[NDK OpenGL ES 3.0 开发（五）：FBO 离屏渲染](https://blog.csdn.net/Kennethdroid/article/details/98883854)中讲到，使用 FBO 进行离屏渲染时，采样时纹理的原点位于屏幕左下角。
那么在 EGLRender 的例子中，使用 FBO 离屏渲染时，直接使用 vFboTexCoors 对纹理进行采样，在 APP 中也不需要再对 buffer 进行镜像操作。